### PR TITLE
feat: Use NUMERIC for more precise summation

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -20,7 +20,7 @@ def check_limits(
 
     # Build query
     query = f"""
-        SELECT DATE(usage_end_time) as usage_day, sku.id AS sku_id, sku.description AS sku_description, project.id as project, sum(cost) as cost, max(currency) as currency 
+        SELECT DATE(usage_end_time) as usage_day, sku.id AS sku_id, sku.description AS sku_description, project.id as project, sum(CAST(cost AS NUMERIC)) as cost, max(currency) as currency 
         FROM `{source_bigquery_table_id}`
         WHERE usage_start_time >= '{n_days_ago}'
         GROUP BY usage_day, project, sku_id, sku_description ORDER BY usage_day


### PR DESCRIPTION
If there are many records, it's better to use NUMERIC (for FLOAT64) for summation.

cf.
https://cloud.google.com/billing/docs/how-to/export-data-bigquery-tables/standard-usage#compute-costs-tagged
https://cloud.google.com/billing/docs/how-to/bq-examples#compute-costs-tagged
https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#decimal_types